### PR TITLE
REFACT Debug player mover is now right-click only

### DIFF
--- a/Assets/Scripts/ClickManager.cs
+++ b/Assets/Scripts/ClickManager.cs
@@ -25,22 +25,6 @@ public class ClickManager : MonoBehaviour
 
     void Update()
     {
-        if (Input.GetMouseButtonDown(0))
-        {
-            Ray ray = mainCamera.ScreenPointToRay(Input.mousePosition);
-            RaycastHit hit;
-
-            if (Physics.Raycast(ray, out hit, Mathf.Infinity, clickableLayer))
-            {
-                BoardTile boardTile = hit.collider.GetComponent<BoardTile>();
-                if (boardTile != null)
-                {
-                    board.playerAnimator.MovePlayerPieceInstantly(boardTile);
-                }
-            }
-
-        }
-
         // Debug Feautre to move the player to an arbitrary tile
         if (Input.GetMouseButtonDown(1))
         {


### PR DESCRIPTION
Because it was possible to press a button and the tile at the same time