### PR TITLE
Prevent powerups from multiplying

### DIFF
--- a/Assets/Scripts/Combat/PlayerCombat.cs
+++ b/Assets/Scripts/Combat/PlayerCombat.cs
@@ -25,7 +25,7 @@ public class PlayerCombat : CombatEntity
         OnStatsChanged?.Invoke();
 
         // Grant the player the basic attack ability
-        AddAbility(new BasicAttackAbility());
+        //AddAbility(new BasicAttackAbility());
     }
 
     public override void Initialise(CombatManager cm, CombatHud hud)
@@ -33,7 +33,7 @@ public class PlayerCombat : CombatEntity
         base.Initialise(cm, hud);
 
         //Set the player's stats to our starting stats
-
+        ClearAllStatusEffects();
 
         foreach (PowerupData pup in powerUps.Values)
         {

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -129,6 +129,11 @@ public class GameManager : Singleton<GameManager>
         return currentEncounter;
     }
 
+    public void ClearEncounters()
+    {
+        encounters = null;
+    }
+
     public void SetCurrentEncounter(EncounterData data)
     {
         currentEncounter = data;

--- a/Assets/Scripts/SceneLoader.cs
+++ b/Assets/Scripts/SceneLoader.cs
@@ -85,6 +85,7 @@ public class SceneLoader : Singleton<SceneLoader>
         {
             Debug.Log("Is newgame reset the player");
             Player.Instance.ResetPlayer();
+            GameManager.Instance.ClearEncounters();
         }
 
         StartCoroutine(FadeAndLoadScene("GameBoard"));


### PR DESCRIPTION
Also properly reset encounters when the player starts a new game